### PR TITLE
Loosen vite (and solid-js) peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "vite": "^2.9.14"
   },
   "peerDependencies": {
-    "solid-js": "^1.4.7",
-    "vite": "^2.9.14"
+    "solid-js": "1.*",
+    "vite": "*"
   }
 }


### PR DESCRIPTION
It seems like `vite-plugin-solid-svg` is working fine in a project where we have these other dependency versions at the moment:

```json5
    // dependencies
    "solid-js": "1.2.x",

    // devDependencies
    "vite": "^3.0.4",
    "vite-plugin-solid": "^2.0.3",
```

<details><summary>Here are the exact versions, though I don't think it matters for the purpose of this PR!</summary>

```
solid-js@1.2.6

# devDependencies
vite@3.0.4
vite-plugin-solid@2.0.3
```

</details>

This required loosening the version requirements for `vite` and `solid-js`, though. Since `vite-plugin-solid-svg` has such a small footprint, I doubt it's coupled to anything in `vite` that had a breaking change from `^2.9.14` to `^3.0.4`. And similarly, it doesn't seem like it needs to care about `solid-js` version _too much_ (maybe as long as it's below 2.0) ... We could change either of these to a different version spec if you prefer. 

In short I think looser would be OK.