### PR TITLE
Props children support

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -8,6 +8,9 @@ declare module 'vite-plugin-solid-svg' {
       enabled?: boolean
       svgoConfig?: OptimizeOptions
     }
+    compilerOptions?: {
+      allow_props_children?: boolean
+    }
   }
 
   function svg(options?: Options): Plugin


### PR DESCRIPTION
resolves #18 

In your `vite.config.ts` you need to allow `props.children`
```
export default defineConfig({
  plugins: [......, solidSvg({compilerOptions: { allow_props_children: true}})],
});
```
With this, you can use `{props.children}` inside your svg file and it will be interpreted by Solid.js
