### PR TITLE
fix TypeScript type when importing SVG as URL

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -39,4 +39,7 @@ declare module '*[name].svg?url' {
   export default dict;
 }
 
-declare module '*.svg?url';
+declare module '*.svg?url' {
+  const src: string;
+  export default src;
+}


### PR DESCRIPTION
Hey, thanks for the plugin!

I ran into an issue where, if importing the SVG as a URL, the imported variable was typed as `any`, now it will be a `string` like how Vite declares the `*.svg` type.

Before:

<img width="528" alt="image" src="https://user-images.githubusercontent.com/9450943/190847221-e1d69c22-e65f-48bd-b654-5c8e8bcda7f0.png">

After:

<img width="562" alt="image" src="https://user-images.githubusercontent.com/9450943/190847230-0b69fa51-d031-467f-b9f5-f7426aba9f08.png">

Let me know what you think!