### PR TITLE
fix: exports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change Log
 
+## [0.6.4] - 2023-07-14
+- Fix `exports` in `package.json`. Correct readme to place typings **before** `vite/client`, order matters.
+
 ## [0.6.3] - 2023-07-10
 - Fix svgo type inference by moving `@types/svgo` from `devDependencies` to `dependencies`
 

--- a/README.md
+++ b/README.md
@@ -48,14 +48,14 @@ If you are using `defaultAsComponent` which is the default, you need to put our 
   ],
 },
 ```
-if you change to `defaultAsComponent=false`, you should use a different type definition that only identifies an svg import as a solid component when it matches the querystring. And in this case, it doesn't matter if you put it before or after `"vite/client"`
+if you change to `defaultAsComponent=false`, you should use a different type definition that only identifies an svg import as a solid component when it matches the querystring. And in this case, put it before `"vite/client"`
 
 ```jsonc
 // tsconfig.json
 "compilerOptions": {
   "types": [
-    "vite/client",
-    "vite-plugin-solid-svg/types"
+    "vite-plugin-solid-svg/types",
+    "vite/client"
   ],
 },
 ```

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vite-plugin-solid-svg",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "description": "Import SVG files as Solid.js Components",
   "keywords": [
     "vite-plugin",

--- a/package.json
+++ b/package.json
@@ -15,12 +15,17 @@
   "license": "MIT",
   "author": "Jorge Godoy <godoy.jf@gmail.com>",
   "exports": {
-    "node": {
-      "import": "./dist/es/index.mjs",
-      "require": "./dist/cjs/index.cjs"
+    "./types": {
+      "types": "./types.d.ts"
     },
-    "import": "./dist/es/index.mjs",
-    "require": "./dist/cjs/index.cjs"
+    "./types-component-solid": {
+      "types": "./types-component-solid.d.ts"
+    },
+    ".": {
+      "import": "./dist/es/index.mjs",
+      "require": "./dist/cjs/index.cjs",
+      "types": "./dist/index.d.ts"
+    }
   },
   "scripts": {
     "build": "rollup -c && tsc"


### PR DESCRIPTION
Typescript need `types` field to resolve types.
See example: https://github.com/vitejs/vite/blob/main/packages/vite/package.json#L21