### PR TITLE
Regex for multiline svg tags

### DIFF
--- a/package/index.ts
+++ b/package/index.ts
@@ -23,7 +23,7 @@ async function compileSvg(source: string, compilerOptions: CompilerOptions) {
   let svgWithProps = source
     .replace(/([{}])/g, "{'$1'}")
     .replace(/<!--\s*([\s\S]*?)\s*-->/g, '{/* $1 */}')
-    .replace(/(?<=<svg.*?)(>)/i, '{...props}>')
+    .replace(/(<svg[^>]*)>/i, '$1{...props}>')
   if (compilerOptions.allow_props_children) {
     svgWithProps = svgWithProps.replace(/\{'\{'\}\s*(props\.children)\s*\{'\}'\}/g, '{$1}')
   }


### PR DESCRIPTION
I had an svg that started like this and props weren't being passed into the component.
```html
<svg
  xmlns="http://www.w3.org/2000/svg"
  viewBox="0 0 40 40"
... etc
>
```

The current regex `/(?<=<svg.*?)(>)/i` uses `.*` which doesn't match newlines. I changed it to `[^>]*` to match everything except the closing bracket.

I also had trouble understanding the lookbehind, so I changed it to use a capture group and `$1`, which I think is easier to understand.

Here are links to text the regex against inputs

Current regex
https://regexr.com/7jor9

This pull request
https://regexr.com/7jorc
