### PR TITLE
fix types resolution

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   "license": "MIT",
   "author": "Jorge Godoy <godoy.jf@gmail.com>",
   "type": "module",
+  "types": "./dist/index.d.ts",
   "exports": {
     "./types": {
       "types": "./types.d.ts"
@@ -40,6 +41,7 @@
   },
   "devDependencies": {
     "eslint": "^8.56.0",
+    "@types/node": "^20.11.30",
     "prettier": "^3.1.1",
     "solid-js": "^1.8.7",
     "tsup": "^8.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,6 +12,9 @@ importers:
         specifier: ^3.1.0
         version: 3.1.0
     devDependencies:
+      '@types/node':
+        specifier: ^20.11.30
+        version: 20.11.30
       eslint:
         specifier: ^8.56.0
         version: 8.56.0
@@ -29,7 +32,7 @@ importers:
         version: 5.3.3
       vite:
         specifier: ^5
-        version: 5.0.10
+        version: 5.0.10(@types/node@20.11.30)
 
   examples/app:
     dependencies:
@@ -42,7 +45,7 @@ importers:
         version: 5.3.3
       vite:
         specifier: ^5
-        version: 5.0.10
+        version: 5.0.10(@types/node@20.11.30)
       vite-plugin-inspect:
         specifier: ^0.8.1
         version: 0.8.1(vite@5.0.10)
@@ -63,7 +66,7 @@ importers:
         version: 5.3.3
       vite:
         specifier: ^5
-        version: 5.0.10
+        version: 5.0.10(@types/node@20.11.30)
       vite-plugin-solid:
         specifier: ^2.8.0
         version: 2.8.0(solid-js@1.8.7)(vite@5.0.10)
@@ -1227,6 +1230,11 @@ packages:
   /@types/estree@1.0.5:
     resolution: {integrity: sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw==}
     dev: true
+
+  /@types/node@20.11.30:
+    resolution: {integrity: sha512-dHM6ZxwlmuZaRmUPfv1p+KrdD1Dci04FbdEm/9wEMouFqxYoFl5aMkt0VMAUtYRQDyYvD41WJLukhq/ha3YuTw==}
+    dependencies:
+      undici-types: 5.26.5
 
   /@ungap/structured-clone@1.2.0:
     resolution: {integrity: sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==}
@@ -2861,6 +2869,9 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
+  /undici-types@5.26.5:
+    resolution: {integrity: sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==}
+
   /universalify@2.0.1:
     resolution: {integrity: sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==}
     engines: {node: '>= 10.0.0'}
@@ -2908,7 +2919,7 @@ packages:
       open: 9.1.0
       picocolors: 1.0.0
       sirv: 2.0.4
-      vite: 5.0.10
+      vite: 5.0.10(@types/node@20.11.30)
     transitivePeerDependencies:
       - rollup
       - supports-color
@@ -2927,7 +2938,7 @@ packages:
       merge-anything: 5.1.7
       solid-js: 1.8.7
       solid-refresh: 0.5.3(solid-js@1.8.7)
-      vite: 5.0.10
+      vite: 5.0.10(@types/node@20.11.30)
       vitefu: 0.2.5(vite@5.0.10)
     transitivePeerDependencies:
       - supports-color
@@ -2955,10 +2966,10 @@ packages:
       fast-glob: 3.3.2
       sirv: 2.0.4
       source-map-support: 0.5.21
-      vite: 5.0.10
+      vite: 5.0.10(@types/node@20.11.30)
     dev: false
 
-  /vite@5.0.10:
+  /vite@5.0.10(@types/node@20.11.30):
     resolution: {integrity: sha512-2P8J7WWgmc355HUMlFrwofacvr98DAjoE52BfdbwQtyLH06XKwaL/FMnmKM2crF0iX4MpmMKoDlNCB1ok7zHCw==}
     engines: {node: ^18.0.0 || >=20.0.0}
     hasBin: true
@@ -2986,6 +2997,7 @@ packages:
       terser:
         optional: true
     dependencies:
+      '@types/node': 20.11.30
       esbuild: 0.19.10
       postcss: 8.4.32
       rollup: 4.9.1
@@ -3000,7 +3012,7 @@ packages:
       vite:
         optional: true
     dependencies:
-      vite: 5.0.10
+      vite: 5.0.10(@types/node@20.11.30)
 
   /webidl-conversions@4.0.2:
     resolution: {integrity: sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==}


### PR DESCRIPTION
This should make the types work correctly in a new Vite Solid project.

See a before/after of the change by viewing [this file of this repo](https://github.com/literalpie/basic-solid-with-svg/blob/main/vite.config.ts) locally.

I tested that things work with and without `"type": "module"`, and with TSConfig moduleResolution set to Node, NodeNext and Bundler.

I also added `@types/node` as a dev dependency, since the build script was failing without that.

Fixes #49 